### PR TITLE
Use netcoreapp TFM in nuspec

### DIFF
--- a/nuspec/SharpSvn.UI.nuspec
+++ b/nuspec/SharpSvn.UI.nuspec
@@ -14,7 +14,7 @@
       <group targetFramework="net40">
         <dependency id="SharpSvn" version="[1.14000.12]" />
       </group>
-      <group targetFramework="netcore">
+      <group targetFramework="netcoreapp">
         <dependency id="SharpSvn" version="[1.14000.12]" />
       </group>
     </dependencies>
@@ -22,7 +22,7 @@
       <group targetFramework="net40">
         <reference file="SharpSvn.UI.dll" />
       </group>
-      <group targetFramework="netcore">
+      <group targetFramework="netcoreapp">
         <reference file="SharpSvn.UI.dll" />
       </group>
     </references>
@@ -31,8 +31,8 @@
     <file target="lib/net40" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.dll" />
     <file target="lib/net40" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.xml" />
     <file target="lib/net40" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.pdb" />
-    <file target="lib/netcore" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.dll" />
-    <file target="lib/netcore" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.xml" />
-    <file target="lib/netcore" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.pdb" />
+    <file target="lib/netcoreapp" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.dll" />
+    <file target="lib/netcoreapp" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.xml" />
+    <file target="lib/netcoreapp" src="..\src\SharpSvn.UI\bin\x86\release\SharpSvn.UI.pdb" />
   </files>
 </package>

--- a/nuspec/SharpSvn.nuspec
+++ b/nuspec/SharpSvn.nuspec
@@ -16,14 +16,14 @@
     <dependencies>
       <group targetFramework="net40">
       </group>
-      <group targetFramework="netcore">
+      <group targetFramework="netcoreapp">
       </group>
     </dependencies>
     <references>
       <group targetFramework="net40">
         <reference file="SharpSvn.dll" />
       </group>
-      <group targetFramework="netcore">
+      <group targetFramework="netcoreapp">
         <reference file="SharpSvn.dll" />
       </group>
     </references>
@@ -55,29 +55,29 @@
 
     <!-- And for .Net Core -->
     <!--  For compile time -->
-    <file target="ref/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.dll" />
-    <file target="ref/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.xml" />
+    <file target="ref/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.dll" />
+    <file target="ref/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.xml" />
 
     <!-- For runtime -->
-    <file target="runtimes/win-x86/lib/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.dll" />
-    <file target="runtimes/win-x86/lib/netcore" src="../src/SharpSvn/bin/win32/releasecore/ijwhost.dll" />
-    <file target="runtimes/win-x86/lib/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.pdb" />
-    <file target="runtimes/win-x86/lib/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.xml" />
-    <file target="runtimes/win-x86/lib/netcore" src="../src/SharpSvn/bin/win32/releasecore/SharpPlink-Win32.svnExe" />
-    <file target="runtimes/win-x86/lib/netcore" src="../imports/release/bin/SharpSvn-DB44-20-win32.svnDll" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.dll" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/ijwhost.dll" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.pdb" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpSvn.xml" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../src/SharpSvn/bin/win32/releasecore/SharpPlink-Win32.svnExe" />
+    <file target="runtimes/win-x86/lib/netcoreapp" src="../imports/release/bin/SharpSvn-DB44-20-win32.svnDll" />
 
-    <file target="runtimes/win-x64/lib/netcore" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.dll" />
-    <file target="runtimes/win-x64/lib/netcore" src="../src/SharpSvn/bin/x64/releasecore/ijwhost.dll" />
-    <file target="runtimes/win-x64/lib/netcore" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.pdb" />
-    <file target="runtimes/win-x64/lib/netcore" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.xml" />
-    <file target="runtimes/win-x64/lib/netcore" src="../src/SharpSvn/bin/x64/releasecore/SharpPlink-x64.svnExe" />
-    <file target="runtimes/win-x64/lib/netcore" src="../imports/release/bin/SharpSvn-DB44-20-x64.svnDll" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.dll" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../src/SharpSvn/bin/x64/releasecore/ijwhost.dll" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.pdb" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../src/SharpSvn/bin/x64/releasecore/SharpSvn.xml" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../src/SharpSvn/bin/x64/releasecore/SharpPlink-x64.svnExe" />
+    <file target="runtimes/win-x64/lib/netcoreapp" src="../imports/release/bin/SharpSvn-DB44-20-x64.svnDll" />
 
-    <file target="runtimes/win-arm64/lib/netcore" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.dll" />
-    <file target="runtimes/win-arm64/lib/netcore" src="../src/SharpSvn/bin/arm64/releasecore/ijwhost.dll" />
-    <file target="runtimes/win-arm64/lib/netcore" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.pdb" />
-    <file target="runtimes/win-arm64/lib/netcore" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.xml" />
-    <file target="runtimes/win-arm64/lib/netcore" src="../src/SharpSvn/bin/arm64/releasecore/SharpPlink-ARM64.svnExe" />
-    <file target="runtimes/win-arm64/lib/netcore" src="../imports/release/bin/SharpSvn-DB44-20-ARM64.svnDll" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.dll" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../src/SharpSvn/bin/arm64/releasecore/ijwhost.dll" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.pdb" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../src/SharpSvn/bin/arm64/releasecore/SharpSvn.xml" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../src/SharpSvn/bin/arm64/releasecore/SharpPlink-ARM64.svnExe" />
+    <file target="runtimes/win-arm64/lib/netcoreapp" src="../imports/release/bin/SharpSvn-DB44-20-ARM64.svnDll" />
   </files>
 </package>


### PR DESCRIPTION
It looks like `netcore` TFM refers to old Windows 8-era "Metro" apps, while to target .NET Core we need to use `netcoreapp`: https://docs.microsoft.com/en-us/nuget/reference/target-frameworks#supported-frameworks

There are more improvements that can be made to .nuspec (e.g. to copy BDB and Plink dependencies to the output directory), but those can be made incrementally and for now can be worked around in a consuming project.

This PR just unblocks the usage of .NET Core versions of SharpSvn.