### PR TITLE
Update workflow steps because of Node.js 16 deprecation

### DIFF
--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -65,7 +65,7 @@ jobs:
           path: imports/release/
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Setup version
         run: scripts\gh-version-setup.cmd ${{ github.run_number }}
@@ -124,7 +124,7 @@ jobs:
           path: imports/release/
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Setup version
         run: scripts\gh-version-setup.cmd ${{ github.run_number }}
@@ -182,7 +182,7 @@ jobs:
           path: imports/release/
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Load dotnet core 3.1.x
         uses: actions/setup-dotnet@v3
@@ -252,7 +252,7 @@ jobs:
           path: imports/release/
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Setup version
         run: scripts\gh-version-setup.cmd ${{ github.run_number }}
@@ -316,7 +316,7 @@ jobs:
           dotnet-version: '3.1.x'
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Setup version
         run: scripts\gh-version-setup.cmd ${{ github.run_number }}
@@ -357,7 +357,7 @@ jobs:
           merge-multiple: true
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Setup version
         run: scripts\gh-version-setup.cmd ${{ github.run_number }}

--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -92,9 +92,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
-      - name: Setup VSTest Path
-        uses: darenm/Setup-VSTest@v1.2
-
       - name: Restore dependency artifacts
         uses: actions/download-artifact@v4
         with:
@@ -107,8 +104,8 @@ jobs:
           name: build-x86-artifacts
           path: src/
 
-      - name: VSTest-x86
-        run: vstest.console.exe /Platform:x86 src/SharpSvn.Tests/bin/x86/Release/SharpSvn.Tests.dll "--testcasefilter:TestCategory!=NeedsNetwork"
+      - name: Dotnet-test-x86
+        run: dotnet vstest /Platform:x86 src/SharpSvn.Tests/bin/x86/Release/SharpSvn.Tests.dll --TestCaseFilter:"TestCategory!=NeedsNetwork"
 
   build-x64:
     needs: dependencies
@@ -150,9 +147,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
-      - name: Setup VSTest Path
-        uses: darenm/Setup-VSTest@v1.2
-
       - name: Restore dependency artifacts
         uses: actions/download-artifact@v4
         with:
@@ -165,8 +159,8 @@ jobs:
           name: build-x64-artifacts
           path: src/
 
-      - name: VSTest-x64
-        run: vstest.console.exe /Platform:x64 src/SharpSvn.Tests/bin/x64/Release/SharpSvn.Tests.dll "--testcasefilter:TestCategory!=NeedsNetwork"
+      - name: Dotnet-test-x64
+        run: dotnet vstest /Platform:x64 src/SharpSvn.Tests/bin/x64/Release/SharpSvn.Tests.dll --TestCaseFilter:"TestCategory!=NeedsNetwork"
 
   build-x86-core:
     needs: dependencies
@@ -215,9 +209,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
-      - name: Setup VSTest Path
-        uses: darenm/Setup-VSTest@v1.2
-
       - name: Restore dependency artifacts
         uses: actions/download-artifact@v4
         with:
@@ -230,8 +221,8 @@ jobs:
           name: build-x86-core-artifacts
           path: src/
 
-      - name: VSTest-Core-x86
-        run: vstest.console.exe /Platform:x86 src/SharpSvn.Tests/bin/x86/ReleaseCore/SharpSvn.Tests.dll "--testcasefilter:TestCategory!=NeedsNetwork"
+      - name: Dotnet-test-Core-x86
+        run: dotnet vstest /Platform:x86 src/SharpSvn.Tests/bin/x86/ReleaseCore/SharpSvn.Tests.dll --TestCaseFilter:"TestCategory!=NeedsNetwork"
 
   build-x64-core:
     needs: dependencies
@@ -279,9 +270,6 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
 
-      - name: Setup VSTest Path
-        uses: darenm/Setup-VSTest@v1.2
-
       - name: Restore dependency artifacts
         uses: actions/download-artifact@v4
         with:
@@ -294,8 +282,8 @@ jobs:
           name: build-x64-core-artifacts
           path: src/
 
-      - name: VSTest-Core-x64
-        run: vstest.console.exe /Platform:x64 src/SharpSvn.Tests/bin/x64/ReleaseCore/SharpSvn.Tests.dll "--testcasefilter:TestCategory!=NeedsNetwork"
+      - name: Dotnet-test-Core-x64
+        run: dotnet vstest /Platform:x64 src/SharpSvn.Tests/bin/x64/ReleaseCore/SharpSvn.Tests.dll --TestCaseFilter:"TestCategory!=NeedsNetwork"
 
   build-arm64-core:
     needs: dependencies

--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install NAnt
         working-directory: imports/
@@ -23,7 +23,7 @@ jobs:
 
       - name: Cache preparations
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             imports/release
@@ -34,7 +34,7 @@ jobs:
   
       - name: Cache Import Downloads
         if: steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             imports/downloads
@@ -185,7 +185,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Load dotnet core 3.1.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.x'
 
@@ -241,7 +241,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Load dotnet core 3.1.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.x'
 
@@ -311,7 +311,7 @@ jobs:
           path: imports/release/
 
       - name: Load dotnet core 3.1.x
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '3.1.x'
 

--- a/.github/workflows/MSBuild.yml
+++ b/.github/workflows/MSBuild.yml
@@ -354,7 +354,7 @@ jobs:
         run: scripts\gh-build-nuget.cmd
 
       - name: Package nupkg files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nupkg-files
           path: nuspec/bin/*.nupkg


### PR DESCRIPTION
Github Actions which use Node.js 16 should be transitioned to Node.js 20
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

-> Also migrated vstest.console.exe to dotnet vstest because https://github.com/darenm/setup-vstest will not update (marked deprecated)